### PR TITLE
fix: change api to return external spotify url

### DIFF
--- a/music-api/Playlist.php
+++ b/music-api/Playlist.php
@@ -5,6 +5,24 @@ class Playlist {
     public $description;
     public $imageUrl;
     public $spotifyUrl;
+    public $externalUrl;
+
+    /**
+     * @return mixed
+     */
+    public function getExternalUrl()
+    {
+        return $this->externalUrl;
+    }
+
+    /**
+     * @param mixed $externalUrl
+     */
+    public function setExternalUrl($externalUrl)
+    {
+        $this->externalUrl = $externalUrl;
+    }
+
 
     /**
      * @return mixed

--- a/music-api/api.php
+++ b/music-api/api.php
@@ -25,7 +25,7 @@ class API
         $curl = curl_init();
 
         curl_setopt_array($curl, [
-            CURLOPT_URL => "https://api.spotify.com/v1/playlists/" . $playlistId . "?fields=name%2Cdescription%2Cimages%2Curi%2Cfollowers",
+            CURLOPT_URL => "https://api.spotify.com/v1/playlists/" . $playlistId . "?fields=name%2Cdescription%2Cimages%2Cexternal_urls%2Cfollowers",
             CURLOPT_RETURNTRANSFER => true,
             CURLOPT_ENCODING => "",
             CURLOPT_MAXREDIRS => 10,
@@ -51,7 +51,7 @@ class API
         $playlist->setDescription($playlistRaw->description);
         $playlist->setImageUrl($playlistRaw->images[0]->url);
         $playlist->setName($playlistRaw->name);
-        $playlist->setSpotifyUrl($playlistRaw->uri);
+        $playlist->setSpotifyUrl($playlistRaw->external_urls->spotify);
         $playlist->setPlaylistId($playlistId);
         return $playlist;
     }

--- a/music-api/api.php
+++ b/music-api/api.php
@@ -25,7 +25,7 @@ class API
         $curl = curl_init();
 
         curl_setopt_array($curl, [
-            CURLOPT_URL => "https://api.spotify.com/v1/playlists/" . $playlistId . "?fields=name%2Cdescription%2Cimages%2Cexternal_urls%2Cfollowers",
+            CURLOPT_URL => "https://api.spotify.com/v1/playlists/" . $playlistId . "?fields=name%2Cdescription%2Cimages%2Cexternal_urls%2Curi%2Cfollowers",
             CURLOPT_RETURNTRANSFER => true,
             CURLOPT_ENCODING => "",
             CURLOPT_MAXREDIRS => 10,
@@ -51,7 +51,8 @@ class API
         $playlist->setDescription($playlistRaw->description);
         $playlist->setImageUrl($playlistRaw->images[0]->url);
         $playlist->setName($playlistRaw->name);
-        $playlist->setSpotifyUrl($playlistRaw->external_urls->spotify);
+        $playlist->setExternalUrl($playlistRaw->external_urls->spotify);
+        $playlist->setSpotifyUrl($playlistRaw->uri);
         $playlist->setPlaylistId($playlistId);
         return $playlist;
     }

--- a/music/package.json
+++ b/music/package.json
@@ -1,6 +1,6 @@
 {
   "name": "music.kevin-kraus.com",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "private": true,
   "dependencies": {
     "@testing-library/jest-dom": "^5.11.4",

--- a/music/src/App.js
+++ b/music/src/App.js
@@ -20,8 +20,7 @@ function App() {
             ReactGA.pageview(window.location.pathname + window.location.search);
         }
         async function loadPlaylists() {
-                var playlists = await fetchPlaylistInfo();
-                return playlists;
+            return await fetchPlaylistInfo();
             }
         loadPlaylists().then((result)=> { setPlaylists(result)});
     }, [playlistsToFetch]);

--- a/music/src/App.scss
+++ b/music/src/App.scss
@@ -1,7 +1,7 @@
+@import "./helper/theme";
 @import "./helper/Breakpoints";
-
 body {
-  background-color: #282c34;
+  background-color: #282c34 !important;
 }
 
 .App {
@@ -22,11 +22,12 @@ body {
   color: white;
 }
 .headerText {
-  margin: 5px 10px 5px 10px;
+  margin: 5px 10px 40px 10px;
 }
 
 .kkraus {
   width: 35vw;
+  margin: 35px
 }
 
 .App-logo {

--- a/music/src/components/Playlist/index.js
+++ b/music/src/components/Playlist/index.js
@@ -1,16 +1,42 @@
-import React from 'react';
+import React, {useState} from 'react';
 import styles from './Playlist.module.scss'
+import Modal from "react-bootstrap/Modal";
+import Button from "react-bootstrap/Button";
+
 function Playlist(props) {
-    return(
-        <a href={props.playlist.url}>
-            <div className={styles.playlistContainer}>
-                <img className={styles.playlistLogo} src={props.playlist.image_url} alt="playlist_logo"/>
-                <div className={styles.playlistDetails}>
-                    <div className={styles.playlistName}>{props.playlist.name}</div>
-                    <div className={styles.playlistDescription}>{props.playlist.description}</div>
+    const [show, setShow] = useState(false);
+
+    const handleClose = () => setShow(false);
+    const handleShow = () => setShow(true);
+
+
+    return (
+        <>
+            <div onClick={handleShow}>
+                <div className={styles.playlistContainer}>
+                    <img className={styles.playlistLogo} src={props.playlist.image_url} alt="playlist_logo"/>
+                    <div className={styles.playlistDetails}>
+                        <div className={styles.playlistName}>{props.playlist.name}</div>
+                        <div className={styles.playlistDescription}>{props.playlist.description}</div>
+                    </div>
                 </div>
             </div>
-        </a>
+
+            <Modal show={show} onHide={handleClose}>
+                <Modal.Header closeButton>
+                    <Modal.Title>Open Playlist "{props.playlist.name}"</Modal.Title>
+                </Modal.Header>
+                <Modal.Body>Please choose whether you have Spotify installed or not.</Modal.Body>
+                <Modal.Footer>
+                    <Button href={props.playlist.externalUrl} variant="secondary" onClick={handleClose}>
+                        Open in Browser
+                    </Button>
+                    <Button href={props.playlist.spotifyUrl} variant="primary" onClick={handleClose}>
+                        Open in Spotify
+                    </Button>
+                </Modal.Footer>
+            </Modal>
+        </>
     )
 }
 

--- a/music/src/helper/theme.scss
+++ b/music/src/helper/theme.scss
@@ -1,0 +1,6 @@
+$theme-colors: (
+        "primary": #BC359B
+);
+
+// Import Bootstrap and its default variables
+@import '~bootstrap/scss/bootstrap.scss';

--- a/music/src/model/spotifyPlaylist.js
+++ b/music/src/model/spotifyPlaylist.js
@@ -3,12 +3,14 @@ class SpotifyPlaylist {
     name;
     description;
     image_url;
-    url;
-    constructor(name, description, imageUrl, uri) {
+    spotifyUrl;
+    externalUrl;
+    constructor(name, description, imageUrl, spotifyUrl, externalUrl) {
         this.name = name;
         this.description = he.decode(description);
         this.image_url = he.decode(imageUrl);
-        this.url = uri;
+        this.spotifyUrl = spotifyUrl;
+        this.externalUrl = externalUrl;
     }
 }
 export default SpotifyPlaylist

--- a/music/src/service/spotify/apiHandler.js
+++ b/music/src/service/spotify/apiHandler.js
@@ -8,9 +8,10 @@ function mapToPlaylist(response) {
     var description = response["description"];
     var images = response["imageUrl"];
     var name = response["name"];
-    var uri = response["spotifyUrl"];
+    var spotifyUrl = response["spotifyUrl"];
+    var externalUrl = response["externalUrl"];
 
-    return new SpotifyPlaylist(name, description, images, uri);
+    return new SpotifyPlaylist(name, description, images, spotifyUrl, externalUrl);
 }
 
 export async function fetchPlaylistInfo() {


### PR DESCRIPTION
API now returns Spotify External URL and Spotify URL. This enables users which don't have spotify installed to still open the links. When User clicks on a playlist he is asked to choose whether to open in Spotify or browser.

fixes #1 